### PR TITLE
Minor dependency bumps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
 		<project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
 		<plexus.errorprone.version>2.7</plexus.errorprone.version>
 		<google.errorprone.version>2.0.9</google.errorprone.version>
-		<http.core.version>4.4.10</http.core.version>
-		<http.client.version>4.5.6</http.client.version>
+		<http.core.version>4.4.11</http.core.version>
+		<http.client.version>4.5.8</http.client.version>
 		<java.version>1.8</java.version>
 		<junit.version>4.12</junit.version>
 		<log4j.version>1.2.17</log4j.version>
@@ -127,7 +127,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.4.3</version>
+				<version>3.1.0</version>
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
 				</configuration>
@@ -135,7 +135,7 @@
 			<plugin>
 				<groupId>org.eluder.coveralls</groupId>
 				<artifactId>coveralls-maven-plugin</artifactId>
-				<version>4.2.0</version>
+				<version>4.3.0</version>
 				<configuration>
 					<timestampFormat>${maven.build.timestamp.format}</timestampFormat>
 				</configuration>
@@ -143,7 +143,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.8</version>
+				<version>0.8.3</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>
@@ -241,7 +241,7 @@
 		<dependency>
 			<groupId>org.bytedeco</groupId>
 			<artifactId>javacv</artifactId>
-			<version>1.3.1</version>
+			<version>1.4.4</version>
 		</dependency>
 	
 	</dependencies>
@@ -267,7 +267,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>2.7</version>
+						<version>3.1.0</version>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>
@@ -280,7 +280,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.1</version>
+						<version>1.6</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>


### PR DESCRIPTION
* Bump jacoco-maven-plugin from 0.7.8 to 0.8.3
* Bump maven-javadoc-plugin from 2.7 to 3.1.0
* Bump maven-resources-plugin from 2.4.3 to 3.1.0
* Bump httpcore from 4.4.10 to 4.4.11