### PR TITLE
Now we can read link type messages from the inbox

### DIFF
--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramInboxThreadLink.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramInboxThreadLink.java
@@ -19,23 +19,17 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.List;
 /**
- * Inbox Thread Item
+ * Inbox Thread Links
  * 
- * @author Krisnamourt da Silva C. Filho
+ * @author Jaydeep Gohel
  *
  */
-@Getter	
+@Getter
 @Setter
 @ToString(callSuper = true)
-public class InstagramInboxThreadItem {
-
-	public String item_id;
-	public String user_id;
-	public long timestamp;
-	public String item_type;
-	public String like;
-	public String link;
+public class InstagramInboxThreadLink{
 	public String text;
-	public InstagramInboxThreadReel reel_share;
+	
 }


### PR DESCRIPTION
Before we are not able to read link types messages for inbox using instagram4j but after reading issues, #311, #243 and #244, I just wanted to summarize it all as a feature request. so figure it out where this issue is and now I make this and we can now read link type message from the inbox.

But still, a new feature is missing to the ability to send link type message in the inbox for that might be @brunocvcunha can help us in the future.