### PR TITLE
iterator for InstagramGetUserFollowersRequest & InstagramGetUserFollowingRequest & clean code

### DIFF
--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramGetUserFollowersRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramGetUserFollowersRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.instagram4j.requests;
 
+import lombok.Setter;
 import org.brunocvcunha.instagram4j.requests.payload.InstagramGetUserFollowersResult;
 
 import lombok.AllArgsConstructor;
@@ -34,6 +35,7 @@ public class InstagramGetUserFollowersRequest extends InstagramGetRequest<Instag
 
     @NonNull
     private long userId;
+    @Setter
     private String maxId;
 
     @Override

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramGetUserFollowingRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramGetUserFollowingRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.instagram4j.requests;
 
+import lombok.Setter;
 import org.brunocvcunha.instagram4j.InstagramConstants;
 import org.brunocvcunha.instagram4j.requests.payload.InstagramGetUserFollowersResult;
 
@@ -35,6 +36,7 @@ public class InstagramGetUserFollowingRequest extends InstagramGetRequest<Instag
 
     @NonNull
     private long userId;
+    @Setter
     private String maxId;
 
     @Override

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramUploadPhotoRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramUploadPhotoRequest.java
@@ -77,14 +77,14 @@ public class InstagramUploadPhotoRequest extends InstagramRequest<InstagramConfi
         this(ImageIO.read(remoteMediaFileURL), caption, uploadId);
     }
   
-    public InstagramUploadPhotoRequest(BufferedImage imageFile, String caption, String uploadId) throws IOException {
+    public InstagramUploadPhotoRequest(BufferedImage imageFile, String caption, String uploadId) {
         this.imageFile = imageFile;
         this.caption = caption;
         this.uploadId = uploadId;
     }
     
     @Override
-    public InstagramConfigurePhotoResult execute() throws ClientProtocolException, IOException {
+    public InstagramConfigurePhotoResult execute() throws IOException {
         
         if (uploadId == null) {
             uploadId = String.valueOf(System.currentTimeMillis());

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramUploadStoryPhotoRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramUploadStoryPhotoRequest.java
@@ -71,7 +71,7 @@ public class InstagramUploadStoryPhotoRequest extends InstagramPostRequest<Insta
     }
     
     @Override
-    public InstagramConfigureStoryResult execute() throws ClientProtocolException, IOException {
+    public InstagramConfigureStoryResult execute() throws IOException {
         
         String uploadId = null;
         

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramGetUserFollowersResultIteratorWrapper.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramGetUserFollowersResultIteratorWrapper.java
@@ -1,0 +1,92 @@
+package org.brunocvcunha.instagram4j.requests.payload;
+
+import org.apache.commons.lang3.Validate;
+import org.brunocvcunha.instagram4j.requests.InstagramGetRequest;
+import org.brunocvcunha.instagram4j.requests.InstagramGetUserFollowersRequest;
+import org.brunocvcunha.instagram4j.requests.InstagramGetUserFollowingRequest;
+
+import java.io.IOException;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Wrapper for iterate through a InstagramGetUserFollowersResult
+ *
+ * @see InstagramGetUserFollowersRequest
+ * @see InstagramGetUserFollowingRequest
+ *
+ * @author meiskalt7
+ */
+public class InstagramGetUserFollowersResultIteratorWrapper implements Iterable<InstagramUserSummary> {
+    InstagramGetUserFollowersResult instagramGetUserFollowersResult;
+    private InstagramGetRequest<InstagramGetUserFollowersResult> instagramGetRequest;
+
+    /**
+     * @param instagramGetRequest request for iterate through results
+     * @throws NullPointerException if api field in instagramGetRequest is null
+     */
+    public InstagramGetUserFollowersResultIteratorWrapper(InstagramGetRequest<InstagramGetUserFollowersResult>
+                                                                  instagramGetRequest
+    ) throws IOException {
+        Validate.notNull(instagramGetRequest.getApi());
+        this.instagramGetRequest = instagramGetRequest;
+        this.instagramGetUserFollowersResult = instagramGetRequest.getApi().sendRequest(instagramGetRequest);
+    }
+
+    @Override
+    public Iterator<InstagramUserSummary> iterator() {
+        return new InstagramGetUserFollowersRequestIterator();
+    }
+
+    /**
+     * Iterator implementation for two requests:
+     *
+     * @see InstagramGetUserFollowersRequest
+     * @see InstagramGetUserFollowingRequest
+     */
+    class InstagramGetUserFollowersRequestIterator implements Iterator<InstagramUserSummary> {
+        int cursor;
+
+        @Override
+        public boolean hasNext() {
+            if (this.cursor == instagramGetUserFollowersResult.getUsers().size() - 1) {
+                return instagramGetUserFollowersResult.getNext_max_id() != null;
+            } else {
+                return true;
+            }
+        }
+
+        @Override
+        public InstagramUserSummary next() {
+            int var1 = this.cursor;
+            if (var1 >= instagramGetUserFollowersResult.getUsers().size() - 1) {
+                if (instagramGetUserFollowersResult.getNext_max_id() == null) {
+                    throw new NoSuchElementException();
+                } else {
+                    try {
+                        if (instagramGetRequest instanceof InstagramGetUserFollowersRequest) {
+                            InstagramGetUserFollowersRequest request = (InstagramGetUserFollowersRequest) instagramGetRequest;
+                            request.setMaxId(instagramGetUserFollowersResult.getNext_max_id());
+                        } else {
+                            InstagramGetUserFollowingRequest request = (InstagramGetUserFollowingRequest) instagramGetRequest;
+                            request.setMaxId(instagramGetUserFollowersResult.getNext_max_id());
+                        }
+                        instagramGetUserFollowersResult = instagramGetRequest.getApi().sendRequest(instagramGetRequest);
+                        this.cursor = 0;
+                        return instagramGetUserFollowersResult.getUsers().get(cursor);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            } else {
+                if (var1 >= instagramGetUserFollowersResult.getUsers().size() - 1) {
+                    throw new ConcurrentModificationException();
+                } else {
+                    this.cursor = var1 + 1;
+                    return instagramGetUserFollowersResult.getUsers().get(cursor);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramMediaTypeEnum.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramMediaTypeEnum.java
@@ -22,6 +22,6 @@ package org.brunocvcunha.instagram4j.requests.payload;
  */
 public enum InstagramMediaTypeEnum {
 
-    PHOTO, VIDEO, ALBUM;
+    PHOTO, VIDEO, ALBUM
 
 }

--- a/src/main/java/org/brunocvcunha/instagram4j/util/InstagramCodeUtil.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/util/InstagramCodeUtil.java
@@ -39,11 +39,11 @@ public class InstagramCodeUtil {
         int padAmount = (int) Math.ceil((double) base2.length() / 6);
         base2 = String.format("%" + padAmount * 6 + "s", base2).replace(' ', '0');
 
-        String encoded = "";
+        StringBuilder encoded = new StringBuilder();
         for (int i = 0; i < padAmount; i++)
-            encoded += BASE64URL_CHARMAP.charAt(Integer.parseInt(base2.substring(6 * i, 6 * i + 6)));
+            encoded.append(BASE64URL_CHARMAP.charAt(Integer.parseInt(base2.substring(6 * i, 6 * i + 6))));
 
-        return encoded;
+        return encoded.toString();
     }
 
     /**
@@ -58,11 +58,11 @@ public class InstagramCodeUtil {
         if (code == null || code.matches("/[^A-Za-z0-9\\-_]/"))
             throw new IllegalArgumentException("Input must be a valid Instagram shortcode.");
 
-        String base2 = "";
+        StringBuilder base2 = new StringBuilder();
         for (char c : code.toCharArray()) {
             int base64 = BASE64URL_CHARMAP.indexOf(c);
-            base2 += String.format("%6s", Integer.toBinaryString(base64)).replace(' ', '0');
+            base2.append(String.format("%6s", Integer.toBinaryString(base64)).replace(' ', '0'));
         }
-        return Long.parseLong(base2, 2);
+        return Long.parseLong(base2.toString(), 2);
     }
 }

--- a/src/main/java/org/brunocvcunha/instagram4j/util/InstagramHashUtil.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/util/InstagramHashUtil.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Bruno Candido Volpato da Cunha (brunocvcunha@gmail.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,25 +15,21 @@
  */
 package org.brunocvcunha.instagram4j.util;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.Charset;
-import java.security.InvalidKeyException;
-import java.security.Key;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-
+import lombok.SneakyThrows;
 import org.apache.commons.codec.binary.Hex;
 import org.brunocvcunha.instagram4j.InstagramConstants;
 
-import lombok.SneakyThrows;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 /**
  * Utilities related to hash
- * 
+ *
  * @author Bruno Candido Volpato da Cunha
  *
  */
@@ -45,7 +41,7 @@ public class InstagramHashUtil {
 
     /**
      * Digest a string using the given codec and input
-     * 
+     *
      * @param codec
      *            Codec to use
      * @param source
@@ -64,7 +60,7 @@ public class InstagramHashUtil {
 
     /**
      * Get the MD5 (in hexadecimal presentation) for the given source
-     * 
+     *
      * @param source
      *            The string to hash
      * @return MD5 hex presentation
@@ -75,7 +71,7 @@ public class InstagramHashUtil {
 
     /**
      * Convert the byte array to a hexadecimal presentation (String)
-     * 
+     *
      * @param bytes
      *            byte array
      * @param initialCount
@@ -104,7 +100,7 @@ public class InstagramHashUtil {
 
     /**
      * Generates Instagram Device ID
-     * 
+     *
      * @param username
      *            Username to generate
      * @param password
@@ -128,9 +124,9 @@ public class InstagramHashUtil {
         SecretKeySpec object = new SecretKeySpec(key.getBytes(), "HmacSHA256");
         try {
             Mac mac = Mac.getInstance("HmacSHA256");
-            mac.init((Key) object);
-            byte[] byteArray = mac.doFinal(string.getBytes("UTF-8"));
-            return new String(new Hex().encode(byteArray), "ISO-8859-1");
+            mac.init(object);
+            byte[] byteArray = mac.doFinal(string.getBytes(StandardCharsets.UTF_8));
+            return new String(new Hex().encode(byteArray), StandardCharsets.ISO_8859_1);
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
f3f4fd1 add iterator for InstagramGetUserFollowersRequest & InstagramGetUserFollowingRequest

Added iterator for GetUserRequests same as iterator in ArrayList. Because the request returns only up to two hundred users at a time, it is necessary to manually iterate through followers/followings every time and this leads to a violation of the DRY principle.

d171d7b and to the add-on I cleaned some code :)

Hope y'all reviewers will approve it