### PR TITLE
Fixed shareType.LINK caused an IllegalArgumentException(Invalid share…

### DIFF
--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramDirectShareRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramDirectShareRequest.java
@@ -74,6 +74,7 @@ public class InstagramDirectShareRequest extends InstagramRequest<StatusResult> 
 			break;
 		case LINK:
 			result = "direct_v2/threads/broadcast/link/";
+			break;	
 		default:
 			throw new IllegalArgumentException("Invalid shareType parameter value: " + shareType);
 		}


### PR DESCRIPTION
…Type parameter value: LINK)