### PR TITLE
Adding set_status endpoint

### DIFF
--- a/src/main/java/com/github/instagram4j/instagram4j/actions/IGClientActions.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/actions/IGClientActions.java
@@ -5,6 +5,7 @@ import com.github.instagram4j.instagram4j.IGClient;
 import com.github.instagram4j.instagram4j.actions.account.AccountAction;
 import com.github.instagram4j.instagram4j.actions.igtv.IgtvAction;
 import com.github.instagram4j.instagram4j.actions.simulate.SimulateAction;
+import com.github.instagram4j.instagram4j.actions.status.StatusAction;
 import com.github.instagram4j.instagram4j.actions.story.StoryAction;
 import com.github.instagram4j.instagram4j.actions.timeline.TimelineAction;
 import com.github.instagram4j.instagram4j.actions.upload.UploadAction;
@@ -23,6 +24,7 @@ public class IGClientActions {
     private SimulateAction _simulate;
     private IgtvAction _igtv;
     private AccountAction _account;
+    private StatusAction _status;
 
     @SneakyThrows
     public IGClientActions(IGClient client) {

--- a/src/main/java/com/github/instagram4j/instagram4j/actions/account/AccountAction.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/actions/account/AccountAction.java
@@ -6,10 +6,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.concurrent.CompletableFuture;
 import com.github.instagram4j.instagram4j.IGClient;
-import com.github.instagram4j.instagram4j.requests.accounts.AccountsChangeProfilePictureRequest;
-import com.github.instagram4j.instagram4j.requests.accounts.AccountsCurrentUserRequest;
-import com.github.instagram4j.instagram4j.requests.accounts.AccountsSetBiographyRequest;
-import com.github.instagram4j.instagram4j.requests.accounts.AccountsActionRequest;
+import com.github.instagram4j.instagram4j.requests.accounts.*;
 import com.github.instagram4j.instagram4j.requests.accounts.AccountsActionRequest.AccountsAction;
 import com.github.instagram4j.instagram4j.responses.IGResponse;
 import com.github.instagram4j.instagram4j.responses.accounts.AccountsUserResponse;
@@ -46,5 +43,9 @@ public class AccountAction {
     
     public CompletableFuture<AccountsUserResponse> currentUser() {
         return new AccountsCurrentUserRequest().execute(client);
+    }
+
+    public CompletableFuture<IGResponse> setStatus(String text, String emoji, long expires_at, boolean should_notify, String status_type) {
+        return new AccountsEditStatusRequest(new AccountsEditStatusRequest.AccountsEditStatusPayload(text,emoji,expires_at,should_notify,status_type)).execute(client);
     }
 }

--- a/src/main/java/com/github/instagram4j/instagram4j/actions/account/AccountAction.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/actions/account/AccountAction.java
@@ -45,6 +45,14 @@ public class AccountAction {
         return new AccountsCurrentUserRequest().execute(client);
     }
 
+    /**
+     * @param text The thread app limit the String to a length to 30 characters, but there are no server verification
+     * @param emoji The thread app prevent you to put anything else that an emoji, but there are no server verification
+     * @param expires_at Must be in second (Example System.currentTimeMillis()/1000+60 for 60 seconds)
+     * @param should_notify Close friend should be notify or not
+     * @param status_type Must be "auto" or "manual"
+     * @return IGResponse
+     */
     public CompletableFuture<IGResponse> setStatus(String text, String emoji, long expires_at, boolean should_notify, String status_type) {
         return new AccountsEditStatusRequest(new AccountsEditStatusRequest.AccountsEditStatusPayload(text,emoji,expires_at,should_notify,status_type)).execute(client);
     }

--- a/src/main/java/com/github/instagram4j/instagram4j/actions/account/AccountAction.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/actions/account/AccountAction.java
@@ -46,6 +46,8 @@ public class AccountAction {
     }
 
     /**
+     * There is a daily limit to the use of setStatus.
+     *
      * @param text The thread app limit the String to a length to 30 characters, but there is no server verification
      * @param emoji The thread app prevent you to put anything else that an emoji, but there is no server verification
      * @param expires_at Must be in second (Example System.currentTimeMillis()/1000+60 for 60 seconds)

--- a/src/main/java/com/github/instagram4j/instagram4j/actions/account/AccountAction.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/actions/account/AccountAction.java
@@ -44,18 +44,4 @@ public class AccountAction {
     public CompletableFuture<AccountsUserResponse> currentUser() {
         return new AccountsCurrentUserRequest().execute(client);
     }
-
-    /**
-     * There is a daily limit to the use of setStatus.
-     *
-     * @param text The thread app limit the String to a length to 30 characters, but there is no server verification
-     * @param emoji The thread app prevent you to put anything else that an emoji, but there is no server verification
-     * @param expires_at Must be in second (Example System.currentTimeMillis()/1000+60 for 60 seconds)
-     * @param should_notify Close friend should be notify or not
-     * @param status_type Must be "auto" or "manual"
-     * @return IGResponse
-     */
-    public CompletableFuture<IGResponse> setStatus(String text, String emoji, long expires_at, boolean should_notify, String status_type) {
-        return new AccountsEditStatusRequest(new AccountsEditStatusRequest.AccountsEditStatusPayload(text,emoji,expires_at,should_notify,status_type)).execute(client);
-    }
 }

--- a/src/main/java/com/github/instagram4j/instagram4j/actions/account/AccountAction.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/actions/account/AccountAction.java
@@ -46,8 +46,8 @@ public class AccountAction {
     }
 
     /**
-     * @param text The thread app limit the String to a length to 30 characters, but there are no server verification
-     * @param emoji The thread app prevent you to put anything else that an emoji, but there are no server verification
+     * @param text The thread app limit the String to a length to 30 characters, but there is no server verification
+     * @param emoji The thread app prevent you to put anything else that an emoji, but there is no server verification
      * @param expires_at Must be in second (Example System.currentTimeMillis()/1000+60 for 60 seconds)
      * @param should_notify Close friend should be notify or not
      * @param status_type Must be "auto" or "manual"

--- a/src/main/java/com/github/instagram4j/instagram4j/actions/status/StatusAction.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/actions/status/StatusAction.java
@@ -25,7 +25,7 @@ public class StatusAction {
      * @return IGResponse
      */
     public CompletableFuture<IGResponse> setStatus(String text, String emoji, long expires_at, boolean should_notify, String status_type) {
-        return new AccountsEditStatusRequest(new AccountsEditStatusRequest.AccountsEditStatusPayload(text,emoji,expires_at,should_notify,status_type)).execute(client);
+        return new StatusSetStatusRequest(new StatusSetStatusRequest.StatusSetStatusPayload(text,emoji,expires_at,should_notify,status_type)).execute(client);
     }
 
     /**

--- a/src/main/java/com/github/instagram4j/instagram4j/actions/status/StatusAction.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/actions/status/StatusAction.java
@@ -25,7 +25,7 @@ public class StatusAction {
      * @return IGResponse
      */
     public CompletableFuture<IGResponse> setStatus(String text, String emoji, long expires_at, boolean should_notify, String status_type) {
-        return new StatusSetStatusRequest(new StatusSetStatusRequest.StatusSetStatusPayload(text,emoji,expires_at,should_notify,status_type)).execute(client);
+        return new StatusSetStatusRequest(text,emoji,expires_at,should_notify,status_type).execute(client);
     }
 
     /**
@@ -35,6 +35,6 @@ public class StatusAction {
      * @return IGResponse
      */
     public CompletableFuture<IGResponse> setStatus(String text, String emoji, long expires_at) {
-        return new StatusSetStatusRequest(new StatusSetStatusRequest.StatusSetStatusPayload(text,emoji,expires_at)).execute(client);
+        return new StatusSetStatusRequest(text,emoji,expires_at).execute(client);
     }
 }

--- a/src/main/java/com/github/instagram4j/instagram4j/actions/status/StatusAction.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/actions/status/StatusAction.java
@@ -1,0 +1,40 @@
+package com.github.instagram4j.instagram4j.actions.status;
+
+import com.github.instagram4j.instagram4j.IGClient;
+import com.github.instagram4j.instagram4j.requests.status.StatusSetStatusRequest;
+import com.github.instagram4j.instagram4j.responses.IGResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class StatusAction {
+    @NonNull
+    private IGClient client;
+
+    /**
+     * There is a daily limit to the use of setStatus.
+     *
+     * @param text The thread app limit the String to a length to 30 characters, but there is no server verification
+     * @param emoji The thread app prevent you to put anything else that an emoji, but there is no server verification
+     * @param expires_at Must be in second (Example System.currentTimeMillis()/1000+60 for 60 seconds)
+     * @param should_notify Close friend should be notify or not
+     * @param status_type Must be "auto" or "manual"
+     * @return IGResponse
+     */
+    public CompletableFuture<IGResponse> setStatus(String text, String emoji, long expires_at, boolean should_notify, String status_type) {
+        return new AccountsEditStatusRequest(new AccountsEditStatusRequest.AccountsEditStatusPayload(text,emoji,expires_at,should_notify,status_type)).execute(client);
+    }
+
+    /**
+     * @param text The thread app limit the String to a length to 30 characters, but there is no server verification
+     * @param emoji The thread app prevent you to put anything else that an emoji, but there is no server verification
+     * @param expires_at Must be in second (Example System.currentTimeMillis()/1000+60 for 60 seconds)
+     * @return IGResponse
+     */
+    public CompletableFuture<IGResponse> setStatus(String text, String emoji, long expires_at) {
+        return new StatusSetStatusRequest(new StatusSetStatusRequest.StatusSetStatusPayload(text,emoji,expires_at)).execute(client);
+    }
+}

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/accounts/AccountsEditStatusRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/accounts/AccountsEditStatusRequest.java
@@ -1,0 +1,55 @@
+package com.github.instagram4j.instagram4j.requests.accounts;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.instagram4j.instagram4j.IGClient;
+import com.github.instagram4j.instagram4j.models.IGPayload;
+import com.github.instagram4j.instagram4j.requests.IGPostRequest;
+import com.github.instagram4j.instagram4j.responses.IGResponse;
+import com.github.instagram4j.instagram4j.responses.accounts.AccountsUserResponse;
+
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+
+@RequiredArgsConstructor
+public class AccountsEditStatusRequest extends IGPostRequest<IGResponse> {
+    @NonNull
+    private AccountsEditStatusPayload payload;
+
+    @Override
+    protected IGPayload getPayload(IGClient client) {
+        return payload;
+    }
+
+    @Override
+    public String path() {
+        return "status/set_status/";
+    }
+
+    @Override
+    public Class<IGResponse> getResponseType() {
+        return IGResponse.class;
+    }
+
+    @Data
+    @Accessors(fluent = true)
+    public static class AccountsEditStatusPayload extends IGPayload {
+        @NonNull
+        @JsonProperty("text")
+        private String text;
+        @NonNull
+        @JsonProperty("emoji")
+        private String emoji;
+        @NonNull
+        @JsonProperty("expires_at")
+        private long expires_at;
+        @NonNull
+        @JsonProperty("should_notify")
+        private boolean should_notify;
+        @NonNull
+        @JsonProperty("status_type")
+        private String status_type;
+    }
+
+}

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/status/StatusSetStatusRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/status/StatusSetStatusRequest.java
@@ -7,6 +7,7 @@ import com.github.instagram4j.instagram4j.requests.IGPostRequest;
 import com.github.instagram4j.instagram4j.responses.IGResponse;
 import com.github.instagram4j.instagram4j.responses.accounts.AccountsUserResponse;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,7 @@ public class StatusSetStatusRequest extends IGPostRequest<IGResponse> {
     }
 
     @Data
+    @AllArgsConstructor
     @Accessors(fluent = true)
     public static class StatusSetStatusPayload extends IGPayload {
         @NonNull
@@ -41,29 +43,25 @@ public class StatusSetStatusRequest extends IGPostRequest<IGResponse> {
         @NonNull
         @JsonProperty("emoji")
         private String emoji;
+
         @JsonProperty("expires_at")
         private long expires_at;
+
         @JsonProperty("should_notify")
         private boolean should_notify;
         @NonNull
         @JsonProperty("status_type")
         private String status_type;
+    }
 
-        public StatusSetStatusPayload(String text, String emoji, long expires_at) {
-            this.text = text;
-            this.emoji = emoji;
-            this.expires_at = expires_at;
-            this.should_notify = false;
-            this.status_type = "manual";
-        }
+    public StatusSetStatusRequest(String text,String emoji,long expires_at)
+    {
+        payload = new StatusSetStatusPayload(text,emoji,expires_at,false,"manual");
+    }
 
-        public StatusSetStatusPayload(String text, String emoji, long expires_at, boolean should_notify, String status_type) {
-            this.text = text;
-            this.emoji = emoji;
-            this.expires_at = expires_at;
-            this.should_notify = should_notify;
-            this.status_type = status_type;
-        }
+    public StatusSetStatusRequest(String text,String emoji,long expires_at,boolean should_notify,String status_type)
+    {
+        payload = new StatusSetStatusPayload(text,emoji,expires_at,should_notify,status_type);
     }
 
 }

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/status/StatusSetStatusRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/status/StatusSetStatusRequest.java
@@ -41,10 +41,8 @@ public class StatusSetStatusRequest extends IGPostRequest<IGResponse> {
         @NonNull
         @JsonProperty("emoji")
         private String emoji;
-        @NonNull
         @JsonProperty("expires_at")
         private long expires_at;
-        @NonNull
         @JsonProperty("should_notify")
         private boolean should_notify;
         @NonNull

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/status/StatusSetStatusRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/status/StatusSetStatusRequest.java
@@ -1,4 +1,4 @@
-package com.github.instagram4j.instagram4j.requests.accounts;
+package com.github.instagram4j.instagram4j.requests.status;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.instagram4j.instagram4j.IGClient;
@@ -13,9 +13,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 
 @RequiredArgsConstructor
-public class AccountsEditStatusRequest extends IGPostRequest<IGResponse> {
+public class StatusSetStatusRequest extends IGPostRequest<IGResponse> {
     @NonNull
-    private AccountsEditStatusPayload payload;
+    private StatusSetStatusRequest.StatusSetStatusPayload payload;
 
     @Override
     protected IGPayload getPayload(IGClient client) {
@@ -34,7 +34,7 @@ public class AccountsEditStatusRequest extends IGPostRequest<IGResponse> {
 
     @Data
     @Accessors(fluent = true)
-    public static class AccountsEditStatusPayload extends IGPayload {
+    public static class StatusSetStatusPayload extends IGPayload {
         @NonNull
         @JsonProperty("text")
         private String text;
@@ -50,6 +50,22 @@ public class AccountsEditStatusRequest extends IGPostRequest<IGResponse> {
         @NonNull
         @JsonProperty("status_type")
         private String status_type;
+
+        public StatusSetStatusPayload(String text, String emoji, long expires_at) {
+            this.text = text;
+            this.emoji = emoji;
+            this.expires_at = expires_at;
+            this.should_notify = false;
+            this.status_type = "manual";
+        }
+
+        public StatusSetStatusPayload(String text, String emoji, long expires_at, boolean should_notify, String status_type) {
+            this.text = text;
+            this.emoji = emoji;
+            this.expires_at = expires_at;
+            this.should_notify = should_notify;
+            this.status_type = status_type;
+        }
     }
 
 }


### PR DESCRIPTION
Instagram allows you to have a status in your profils. However you cannot set it directly from the Instagram application, you need to use the [Thread app by Instagram](https://www.theverge.com/2019/10/3/20895368/instagram-threads-messaging-app-close-friends-ios-android-text-photo-video).

The thread app is simply a copy of the Instagram app, so they are using the same private API. Therefore you can call the `status/set_status` end point using an Instagram login token.

I tested it, it works fine, however they are a daily rate limit which is very low, I think it is something like 50-100 usage per day (Not sure), I get the 429 error code after testing a bit, and have to wait the tomorrow morning for being able to do it again.