### PR TITLE
Fix ThreadMediaItem deserialization

### DIFF
--- a/src/main/java/com/github/instagram4j/instagram4j/models/direct/item/ThreadMediaItem.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/models/direct/item/ThreadMediaItem.java
@@ -1,10 +1,12 @@
 package com.github.instagram4j.instagram4j.models.direct.item;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.github.instagram4j.instagram4j.models.media.thread.ThreadMedia;
 
 import lombok.Data;
 
 @Data
+@JsonTypeName("media")
 public class ThreadMediaItem extends ThreadItem {
     private ThreadMedia media;
 }


### PR DESCRIPTION
The ThreadMediaItem class was missing the type annotation for Jackson. This fixes that.