### PR TITLE
Added slf4j-nop to remove warning message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     api 'com.fasterxml.jackson.core:jackson-databind:2.11.0'
     api 'com.fasterxml.jackson.core:jackson-annotations:2.11.0'
     api 'org.slf4j:slf4j-api:1.7.30'
+    api 'org.slf4j:slf4j-nop:1.7.30'
     // Test utilities
     testImplementation 'org.slf4j:slf4j-log4j12:1.7.30'
     testImplementation 'com.squareup.okhttp3:logging-interceptor:4.7.2'


### PR DESCRIPTION
Adding slf4j-nop will remove the "Failed to load class org.slf4j.impl.StaticLoggerBinder" warning message at the start.
