### PR TITLE
Search between accounts

### DIFF
--- a/src/main/java/com/github/instagram4j/instagram4j/requests/accountsearch/AccountSearch.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/accountsearch/AccountSearch.java
@@ -1,0 +1,89 @@
+package com.github.instagram4j.instagram4j.requests.accountsearch;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import com.github.instagram4j.instagram4j.IGClient;
+import com.github.instagram4j.instagram4j.responses.accountsearch.AccountSearchResponse;
+
+import lombok.Getter;
+
+public class AccountSearch {
+
+	private IGClient client;
+	private String query;
+	
+	@Getter private int currentPageN;
+	 
+	private List<AccountSearchResponse> pages = new ArrayList<>();
+	
+	public AccountSearch(IGClient client, String query) {
+		this.client = client;
+		this.query = query;
+		this.currentPageN = 0;
+		
+		search();
+	}
+	
+	private void search() {
+		int j = 0;
+		while (true) {		
+			if(j== 0) {
+				AccountSearchResponse asr = null;				
+				try {
+					asr = new AccountSearchRequest(query).
+							execute(client).get();
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				} catch (ExecutionException e) {
+					e.printStackTrace();
+				}				
+				pages.add(asr);
+			}else {
+				if(!pages.get(j-1).isHas_more()) 
+					break;
+				
+				AccountSearchResponse asr = null;				
+				try {
+					asr = new AccountSearchTokenRequest(query, pages.get(j-1).getRank_token(), pages.get(j-1).getPage_token()).
+							execute(client).get();
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				} catch (ExecutionException e) {
+					e.printStackTrace();
+				}
+				pages.add(asr);
+			}
+			
+			j++;
+		}	
+		pages.remove(0);
+	}
+	
+	public AccountSearchResponse getCurrentPage() {
+		return pages.get(currentPageN);
+	}
+	
+	public AccountSearchResponse getPageAt(int pos) {
+		if(pos>=0 && pos < pages.size())
+			return pages.get(pos);
+		return null;
+	}
+	
+	public void nextPage() {
+		if(currentPageN < pages.size()-1)
+			currentPageN++;
+	}
+	
+	
+	public void beforePage() {
+		if(currentPageN > 0) 
+			currentPageN--;
+	}
+	
+	public int getTotalPages() {
+		return pages.size();
+	}
+	
+}

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/accountsearch/AccountSearchRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/accountsearch/AccountSearchRequest.java
@@ -1,0 +1,33 @@
+package com.github.instagram4j.instagram4j.requests.accountsearch;
+
+import com.github.instagram4j.instagram4j.IGClient;
+import com.github.instagram4j.instagram4j.requests.IGGetRequest;
+import com.github.instagram4j.instagram4j.responses.accountsearch.AccountSearchResponse;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+@AllArgsConstructor
+public class AccountSearchRequest extends IGGetRequest<AccountSearchResponse> {
+
+	@NonNull
+	private String q;
+	
+	@Override
+    public String path() {       
+        return "users/search/";
+    }
+
+	@Override
+    public String getQueryString(IGClient client) {      
+        return mapQueryString("search_surface", "user_search_page", 
+        					  "timezone_offset", "7200",
+        					  "q", q,
+        					  "count", "30");
+    }
+		
+	@Override
+	public Class<AccountSearchResponse> getResponseType() {
+		return AccountSearchResponse.class;
+	}
+}

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/accountsearch/AccountSearchTokenRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/accountsearch/AccountSearchTokenRequest.java
@@ -1,0 +1,40 @@
+package com.github.instagram4j.instagram4j.requests.accountsearch;
+
+import com.github.instagram4j.instagram4j.IGClient;
+import com.github.instagram4j.instagram4j.requests.IGGetRequest;
+import com.github.instagram4j.instagram4j.responses.accountsearch.AccountSearchResponse;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+
+@AllArgsConstructor
+public class AccountSearchTokenRequest extends IGGetRequest<AccountSearchResponse> {
+
+	@NonNull
+	private String q;
+	@NonNull
+	private String rank_token;	
+	@NonNull
+	private String page_token;
+	
+	@Override
+    public String path() {       
+        return "users/search/";
+    }
+	
+	@Override
+    public String getQueryString(IGClient client) {      
+        return mapQueryString("search_surface", "user_search_page", 
+        					  "timezone_offset", "7200",
+        					  "q", q,
+        					  "count", "30",
+        					  "rank_token", rank_token,
+        					  "page_token", page_token);
+    }
+		
+	@Override
+	public Class<AccountSearchResponse> getResponseType() {
+		return AccountSearchResponse.class;
+	}
+}

--- a/src/main/java/com/github/instagram4j/instagram4j/responses/accountsearch/AccountSearchResponse.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/responses/accountsearch/AccountSearchResponse.java
@@ -1,0 +1,18 @@
+package com.github.instagram4j.instagram4j.responses.accountsearch;
+
+import java.util.List;
+
+import com.github.instagram4j.instagram4j.models.user.Profile;
+import com.github.instagram4j.instagram4j.responses.IGResponse;
+
+import lombok.Data;
+
+@Data
+public class AccountSearchResponse extends IGResponse {
+	private int num_results;
+	private List<Profile> users;
+	
+	private String rank_token;
+    private String page_token;
+    private boolean has_more;
+}


### PR DESCRIPTION
#506 
Using classes AccountSearchRequest & AccountSearchResponse it works correctly but returns only the first 21 users (the first request) that are searched.
Usage:  
```
        new AccountSearchRequest("something to search").execute(client)
    	.thenAccept(response -> {
    		response.getUsers().forEach(System.out::println);
    	}).join();
```
So I created the AccountSearchTokenRequest class for requests with rank_token and page_token. But so the class is useless without AccountSearch with which you can get all the 'pages' of the requests with the list of the returned accounts.
Usage:
```
        AccountSearch as = new AccountSearch(client, "something to search");    
        System.out.println("Total pages: " + as.getTotalPages());
        for(int j = 0; j<as.getTotalPages(); j++) {
        	System.out.println("Page number " + as.getCurrentPageN());
        	as.getCurrentPage().getUsers().forEach(u->System.out.println(u.getUsername()));
        	as.nextPage();    	
        }
```