### PR TITLE
special character issue fixed.

### DIFF
--- a/src/main/java/com/github/instagram4j/instagram4j/requests/accounts/AccountsActionRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/accounts/AccountsActionRequest.java
@@ -5,6 +5,8 @@ import com.github.instagram4j.instagram4j.models.IGPayload;
 import com.github.instagram4j.instagram4j.requests.IGPostRequest;
 import com.github.instagram4j.instagram4j.responses.accounts.AccountsUserResponse;
 
+import java.util.Locale;
+
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
@@ -20,7 +22,7 @@ public class AccountsActionRequest extends IGPostRequest<AccountsUserResponse> {
 
     @Override
     public String path() {
-        return "accounts/" + action.name().toLowerCase() + "/";
+        return "accounts/" + action.name().toLowerCase(new Locale("en", "US")) + "/";
     }
 
     @Override

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/direct/DirectThreadsActionRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/direct/DirectThreadsActionRequest.java
@@ -5,6 +5,8 @@ import com.github.instagram4j.instagram4j.models.IGPayload;
 import com.github.instagram4j.instagram4j.requests.IGPostRequest;
 import com.github.instagram4j.instagram4j.responses.IGResponse;
 
+import java.util.Locale;
+
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
@@ -22,7 +24,7 @@ public class DirectThreadsActionRequest extends IGPostRequest<IGResponse> {
 
     @Override
     public String path() {
-        return String.format("direct_v2/threads/%s/%s/", thread_id, action.name().toLowerCase());
+        return String.format("direct_v2/threads/%s/%s/", thread_id, action.name().toLowerCase(new Locale("en", "US")));
     }
 
     @Override

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/friendships/FriendshipsActionRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/friendships/FriendshipsActionRequest.java
@@ -5,6 +5,8 @@ import com.github.instagram4j.instagram4j.models.IGPayload;
 import com.github.instagram4j.instagram4j.requests.IGPostRequest;
 import com.github.instagram4j.instagram4j.responses.friendships.FriendshipStatusResponse;
 
+import java.util.Locale;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +28,7 @@ public class FriendshipsActionRequest extends IGPostRequest<FriendshipStatusResp
 
     @Override
     public String path() {
-        return String.format("friendships/%s/%s/", action.name().toLowerCase(), _pk);
+        return String.format("friendships/%s/%s/", action.name().toLowerCase(new Locale("en", "US")), _pk);
     }
 
     @Override

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/friendships/FriendshipsFeedsRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/friendships/FriendshipsFeedsRequest.java
@@ -5,6 +5,8 @@ import com.github.instagram4j.instagram4j.requests.IGGetRequest;
 import com.github.instagram4j.instagram4j.requests.IGPaginatedRequest;
 import com.github.instagram4j.instagram4j.responses.feed.FeedUsersResponse;
 
+import java.util.Locale;
+
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +30,7 @@ public class FriendshipsFeedsRequest extends IGGetRequest<FeedUsersResponse>
 
     @Override
     public String path() {
-        return String.format("friendships/%s/%s/", _id, action.name().toLowerCase());
+        return String.format("friendships/%s/%s/", _id, action.name().toLowerCase(new Locale("en", "US")));
     }
 
     @Override

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/media/MediaActionRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/media/MediaActionRequest.java
@@ -5,6 +5,8 @@ import com.github.instagram4j.instagram4j.models.IGPayload;
 import com.github.instagram4j.instagram4j.requests.IGPostRequest;
 import com.github.instagram4j.instagram4j.responses.IGResponse;
 
+import java.util.Locale;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +28,7 @@ public class MediaActionRequest extends IGPostRequest<IGResponse> {
 
     @Override
     public String path() {
-        return String.format("media/%s/%s/", _media_id, action.name().toLowerCase());
+        return String.format("media/%s/%s/", _media_id, action.name().toLowerCase(new Locale("en", "US")));
     }
 
     @Override

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/upload/RuploadSegmentVideoPhaseRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/upload/RuploadSegmentVideoPhaseRequest.java
@@ -7,6 +7,8 @@ import com.github.instagram4j.instagram4j.requests.IGPostRequest;
 import com.github.instagram4j.instagram4j.responses.IGResponse;
 import com.github.instagram4j.instagram4j.utils.IGUtils;
 
+import java.util.Locale;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
@@ -48,7 +50,7 @@ public class RuploadSegmentVideoPhaseRequest extends IGPostRequest<IGResponse> {
 
     @Override
     public String getQueryString(IGClient client) {
-        return mapQueryString("segmented", "true", "phase", phase.name().toLowerCase());
+        return mapQueryString("segmented", "true", "phase", phase.name().toLowerCase(new Locale("en", "US")));
     }
 
     @Override


### PR DESCRIPTION
Special characters change the endpoint URLs when the enums are converted to lowercase in the request. The response of Instagram is 404 in this situation. This happens when the device language is different than English. (i.e: Turkish) 
