### PR TITLE
Fix 429 login code response.

### DIFF
--- a/src/main/java/com/github/instagram4j/instagram4j/IGClient.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/IGClient.java
@@ -97,9 +97,12 @@ public class IGClient implements Serializable {
 
     public CompletableFuture<LoginResponse> sendLoginRequest() {
         return new QeSyncRequest().execute(this)
-                .thenCompose(res -> new AccountsLoginRequest($username,
-                        IGUtils.encryptPassword(this.$password, this.encryptionId,
-                                this.encryptionKey)).execute(this))
+                .thenCompose(res -> {
+                    IGUtils.sleepSeconds(1);
+                    return new AccountsLoginRequest($username,
+                            IGUtils.encryptPassword(this.$password, this.encryptionId,
+                                    this.encryptionKey)).execute(this);
+                })
                 .thenApply((res) -> {
                     this.setLoggedInState(res);
 


### PR DESCRIPTION
Instagram almost always response me with the code 429 (_Please wait a few minutes before you try again_), when I try to login.
I found, that for the first request _/qe/sync/_ everything is fine, code 200 was returned. But for the next request _/accounts/login/_ I'm getting 429 error code. I noticed after several tries that this code appears when the delay between sending 2 requests less than ~800ms. So I just decided to add delay in 1 sec using existed _sleepSeconds()_ method from _IGUtils_.

P.S. I don't have such problem when I'm running my app on my laptop, there is always a natural delay about 1 sec between those requests. But problem appears when I deploy my app on my server. That delay is reduced to 100-300ms for 90% of my test login requests.