### PR TITLE
Added `min_timestamp` and `max_timestamp` to FeedUserRequest

### DIFF
--- a/src/main/java/com/github/instagram4j/instagram4j/requests/feed/FeedUserRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/feed/FeedUserRequest.java
@@ -18,6 +18,10 @@ public class FeedUserRequest extends IGGetRequest<FeedUserResponse>
     private Long pk;
     @Setter
     private String max_id;
+    @Setter
+    private String min_timestamp;
+    @Setter
+    private String max_timestamp;
 
     @Override
     public String path() {
@@ -26,7 +30,7 @@ public class FeedUserRequest extends IGGetRequest<FeedUserResponse>
 
     @Override
     public String getQueryString(IGClient client) {
-        return this.mapQueryString("max_id", max_id);
+        return this.mapQueryString("max_id", max_id, "min_timestamp", min_timestamp, "max_timestamp", max_timestamp);
     }
 
     @Override

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/feed/FeedUserRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/feed/FeedUserRequest.java
@@ -19,9 +19,9 @@ public class FeedUserRequest extends IGGetRequest<FeedUserResponse>
     @Setter
     private String max_id;
     @Setter
-    private String min_timestamp;
+    private Long min_timestamp;
     @Setter
-    private String max_timestamp;
+    private Long max_timestamp;
 
     @Override
     public String path() {


### PR DESCRIPTION
This query params were in the previous version of the library and still work I guess. May be add some more suitable constructor or the builder.