### PR TITLE
Fix defaultImpl class for TimelineMedia JSON deserialization

### DIFF
--- a/src/main/java/com/github/instagram4j/instagram4j/models/media/timeline/TimelineMedia.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/models/media/timeline/TimelineMedia.java
@@ -11,7 +11,7 @@ import com.github.instagram4j.instagram4j.models.media.UserTags;
 import lombok.Data;
 
 @Data
-@JsonTypeInfo(defaultImpl = Media.class, use = JsonTypeInfo.Id.NAME,
+@JsonTypeInfo(defaultImpl = TimelineMedia.class, use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY, property = "media_type", visible = true)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = TimelineImageMedia.class),


### PR DESCRIPTION
`TimelineMedia `can not be deserialized becouse of wrong specified `defaultImpl`. 
As I understand `defaultImpl `class must be child or the same class.
With the `Media `class specified JSON deserializer throws the exception: 
`java.lang.IllegalArgumentException: Class com.github.instagram4j.instagram4j.models.media.timeline.TimelineMedia not subtype of [simple type, class com.github.instagram4j.instagram4j.models.media.Media]`
This change will fix the issue.