### PR TITLE
Add reverse cursor of media comments

### DIFF
--- a/src/main/java/com/github/instagram4j/instagram4j/requests/media/MediaGetCommentsRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/media/MediaGetCommentsRequest.java
@@ -17,6 +17,8 @@ public class MediaGetCommentsRequest extends IGGetRequest<MediaGetCommentsRespon
     @NonNull
     private String _id;
     @Setter
+    private String min_id;
+    @Setter
     private String max_id;
 
     @Override
@@ -26,7 +28,7 @@ public class MediaGetCommentsRequest extends IGGetRequest<MediaGetCommentsRespon
 
     @Override
     public String getQueryString(IGClient client) {
-        return mapQueryString("max_id", max_id);
+        return mapQueryString("min_id", min_id, "max_id", max_id);
     }
 
     @Override

--- a/src/main/java/com/github/instagram4j/instagram4j/responses/media/MediaGetCommentsResponse.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/responses/media/MediaGetCommentsResponse.java
@@ -12,8 +12,9 @@ public class MediaGetCommentsResponse extends IGResponse implements IGPaginatedR
     private List<Comment> comments;
     private Caption caption;
     private String next_max_id;
+    private String next_min_id;
 
     public boolean isMore_available() {
-        return next_max_id != null;
+        return next_max_id != null || next_min_id != null;
     }
 }


### PR DESCRIPTION
`next_max_id` field was always `null` while I testing the library. I dug into the problem and found that Instagram often fills `next_min_id` field instead of `next_max_id`. I supose you can choose the direction of pagination, but I don't know the query parameter name to do it. Pagination works well if you put `next_min_id` value as `min_id` parameter to get next page.
Also found the same in this library: https://github.com/dilame/instagram-private-api/commit/a3b2d950d2c2923862264da2b1ec64c4b203eb45 