### PR TITLE
Correct README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-
-
-
-
 instagram4j
 ========
 ![Java CI with Gradle](https://github.com/instagram4j/instagram4j/workflows/Java%20CI%20with%20Gradle/badge.svg?branch=develop)
@@ -11,6 +7,7 @@ instagram4j
 :camera: Java wrapper using OkHttpClient for Instagram's private api (Android emulation)
 ## Table of contents
  - [Install](#install)
+     - [Requirements](#requirements)
  - [Overview](#overview)
      - [Features](#features)
  - [Usage](#usage)
@@ -115,7 +112,6 @@ This library is in no way affiliated with, authorized, maintained, sponsored or 
 
 Contributors are not responsible for usage and maintainability. Due to the nature of this project, some features of the library are not guaranteed as they make change and break in the future. This library is licensed under ASL.
 
----
 ## Quick Usage
 **Login:**
 ```java


### PR DESCRIPTION
Corrections have been made:
- Spaces at the beginning
- Removed “---” before `### Quick usage`
- Added Requirments sub-block to ### Table of contents

The “---” in front of `### Quick usage` was removed, as the lane creates itself and using “---” for this was necessary. But when using this, another stripe is created, so it becomes fatter than all the others.
![image](https://github.com/user-attachments/assets/d1e747e9-dc05-46ec-80d7-7a3898b454ce)

Also, since we have sub-blocks for blocks (i.e. for example Usage has a `Terms and Conditions` sub-block, and it is listed as a sub-block in the `Table of contents`), I think we want to fix and add the `Requirements` sub-block to `Install` in the `Table of contents`