### PR TITLE
docs: fix typo in checkpoints documentation

### DIFF
--- a/checkpoints.md
+++ b/checkpoints.md
@@ -6,7 +6,7 @@ As we all know Instagram is improving its platform security day by day. It is ma
 -  [We Detected An Unusual Login Attempt](/#we-detected-an-unusual-login-attempt)
 - [We suspected automation behaviour](/#we-suspected-automation-behaviour)
 
-These are the most frequently occured checkpoints. If discovered, it will be appended to this table.
+These are the most frequently occurred checkpoints. If discovered, it will be appended to this table.
 Below is the detail on each checkpoint and how to resolve them.
 
 


### PR DESCRIPTION
Fixes a small spelling typo in checkpoints.md: `occured` → `occurred`.

This is a documentation-only change.